### PR TITLE
nautible/issues#56

### DIFF
--- a/overlays/dev/product-deployment.yaml
+++ b/overlays/dev/product-deployment.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/part-of: nautible
     app.kubernetes.io/managed-by: manual
 spec:
-  replicas: 1
   template:
     spec:
       containers:


### PR DESCRIPTION
# issue 56
## issue
- https://github.com/nautible/issues/issues/56

## 対応
- base の Deployment が replicas: 2 なので、dev の Deployment で指定していた replicas: 1 を削除して、dev のレプリカ数が2になるよう対応をしました。
